### PR TITLE
Update PanAz.schelp

### DIFF
--- a/HelpSource/Classes/PanAz.schelp
+++ b/HelpSource/Classes/PanAz.schelp
@@ -60,15 +60,15 @@ section::Comparison to Pan2
 Despite a certain similarity, link::Classes/Pan2:: and link::Classes/PanAz:: with 2 channels behave differently.
 
 code::
-// one full cycle for PanAz: from 0 to 1
-{ PanAz.ar(2, DC.ar(1), Line.ar(0, 1, 0.1)) }.plot(0.1)
+// one full cycle for PanAz: from 0 to 2 
+{ PanAz.ar(2, DC.ar(1), Line.ar(0, 2, 0.1), orientation: 0) }.plot(0.1)
 // one full cycle for Pan2: from -1 to 1 and back to -1
-{ Pan2.ar(DC.ar(1), EnvGen.kr(Env([-1, 1, -1], [0.05, 0.05]))) }.plot(0.1)
+{ Pan2.ar(DC.ar(1), EnvGen.ar(Env([-1, 1, -1], [0.05, 0.05]))) }.plot(0.1)
 
-// in other words, while Pan2 makes one full transition
+// in other words, while Pan2 needs a position change of 2 from channel 0 to 1
 { Pan2.ar(DC.ar(1), Line.ar(-1, 1, 0.1)) }.plot(0.1)
-// we need only a half one in PanAz:
-{ PanAz.ar(2, DC.ar(1), Line.ar(0, 1/2, 0.1)) }.plot(0.1)
+// we need a position change of 1 in PanAz:
+{ PanAz.ar(2, DC.ar(1), Line.ar(0, 1, 0.1), orientation: 0) }.plot(0.1)
 ::
 
 


### PR DESCRIPTION
This is related to #3148, #3149 and #3150, I tried to keep the structure of the example.
If you haven't yet compiled LFSaw's fix you can check with Line.kr versions in PanAz, they now behave like the ar versions (kr versions show an init jump in the plot, so ar is nicer).